### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ encryption_manager.cpp
 
 #.ini files
 *.ini
+
+#gh pr create files
+body.txt
+title.txt


### PR DESCRIPTION
Updated .gitignore file. Now excludes body.txt & title.txt, which are used for creating pull requests.